### PR TITLE
Fix for /etc/redis.conf file

### DIFF
--- a/include/tests_databases
+++ b/include/tests_databases
@@ -190,35 +190,37 @@
     Register --test-no DBS-1882 --weight L --network NO --preqs-met "${PREQS_MET}" --skip-reason "${SKIPREASON}" --category security --description "Redis configuration file"
     if [ ${SKIPTEST} -eq 0 ]; then
         PATHS="${ROOTDIR}etc/redis ${ROOTDIR}usr/local/etc/redis"
+        ALLFILES=$( ${LSBINARY} ${ROOTDIR}etc/redis.conf 2> /dev/null)
         FOUND=0
         for DIR in ${PATHS}; do
             LogText "Action: scanning directory (${DIR}) for Redis configuration files"
             FILES=$(${LSBINARY} ${DIR}/*.conf 2> /dev/null)
             if [ ! -z "${FILES}" ]; then
-                for CONFFILE in ${FILES}; do
-                    if FileIsReadable ${CONFFILE}; then
-                        LogText "Action: checking if ${CONFFILE} is a Sentinel configuration file"
-                        # Exclude Sentinel configuration file
-                        FIND=$(${GREPBINARY} "^sentinel " ${CONFFILE})
-                        if [ ! -z "${FIND}" ]; then
-                            LogText "Result: file is a Sentinel configuration file, skipping it"
-                        else
-                            LogText "Result: file is NOT a Sentinel configuration file. Now scanning if it is a Redis configuration file"
-                            FIND=$(${GREPBINARY} "Redis" ${CONFFILE})
-                            if [ ! -z "${FIND}" ]; then
-                                REDIS_CONFIGURATION_FILES="${REDIS_CONFIGURATION_FILES} ${CONFFILE}"
-                                REDIS_CONFIGURATION_FOUND=1
-                                LogText "Result: found a Redis configuration file (${CONFFILE})"
-                            else
-                                LogText "Result: this file does not look like a Redis file  (${CONFFILE})"
-                            fi
-                        fi
-                    else
-                        LogText "Could not read this file, so skipping it"
-                    fi
-                done
+                ALLFILES="${ALLFILES} ${FILES}"
             else
                 LogText "Result: no configuration files found in this directory"
+            fi
+        done
+        for CONFFILE in ${ALLFILES}; do
+            if FileIsReadable ${CONFFILE}; then
+                LogText "Action: checking if ${CONFFILE} is a Sentinel configuration file"
+                # Exclude Sentinel configuration file
+                FIND=$(${GREPBINARY} "^sentinel " ${CONFFILE})
+                if [ ! -z "${FIND}" ]; then
+                    LogText "Result: file is a Sentinel configuration file, skipping it"
+                else
+                    LogText "Result: file is NOT a Sentinel configuration file. Now scanning if it is a Redis configuration file"
+                    FIND=$(${GREPBINARY} "Redis" ${CONFFILE})
+                    if [ ! -z "${FIND}" ]; then
+                        REDIS_CONFIGURATION_FILES="${REDIS_CONFIGURATION_FILES} ${CONFFILE}"
+                        REDIS_CONFIGURATION_FOUND=1
+                        LogText "Result: found a Redis configuration file (${CONFFILE})"
+                    else
+                        LogText "Result: this file does not look like a Redis file  (${CONFFILE})"
+                    fi
+                fi
+            else
+                LogText "Could not read this file, so skipping it"
             fi
         done
         # Sort the list of discovered configuration files so we can make them unique


### PR DESCRIPTION
The /etc/redis.conf files as in use on gentoo was missing in the search.
The Directory loop has been changed to produce a list of files.  In stead of immediately checking the files.
After that the list of files is examined.